### PR TITLE
feat: allow missing `patch`

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -27,8 +27,8 @@ lazy_static! {
             (?P<major>{})           # major version
             \.                      # dot
             (?P<minor>{})           # minor version
-            \.                      # dot
-            (?P<patch>{})           # patch version
+            \.?                     # optional dot
+            (?P<patch>{})?          # optional patch version
             (:?-(?P<pre>{}))?       # optional prerelease version
             (:?\+(?P<build>{}))?    # optional build metadata
             $",
@@ -75,7 +75,7 @@ pub fn parse(version: &str) -> Result<Version, String> {
     Ok(Version {
         major: captures.name("major").unwrap().parse().unwrap(),
         minor: captures.name("minor").unwrap().parse().unwrap(),
-        patch: captures.name("patch").unwrap().parse().unwrap(),
+        patch: captures.name("patch").unwrap_or("0").parse().unwrap(),
         pre: pre,
         build: build,
     })
@@ -109,7 +109,6 @@ impl fmt::Display for Identifier {
 
 #[cfg(test)]
 mod tests {
-    use common::is_alpha_numeric;
     use version;
     use super::*;
 
@@ -144,9 +143,11 @@ mod tests {
     fn parse_no_patch() {
         let version = "1.2";
 
-        let parsed = version::parse(version);
+        let parsed = version::parse(version).unwrap();
 
-        assert!(parsed.is_err(), format!("'{}' incorrectly considered a valid parse", version));
+        assert_eq!(1, parsed.major);
+        assert_eq!(2, parsed.minor);
+        assert_eq!(0, parsed.patch);
     }
 
     #[test]


### PR DESCRIPTION
According to [semver](http://semver.org/) _2.0.0_, a **normal** version is defined as:

> "A **normal** version number MUST take the form X.Y.Z where X, Y, and Z are non-negative integers, and MUST NOT contain leading zeroes. X is the major version, Y is the minor version, and Z is the patch version. Each element MUST increase numerically. For instance: 1.9.0 -> 1.10.0 -> 1.11.0."

source: [spec-item-2](http://semver.org/#spec-item-2)

It is my understanding, and what seems to be common practice in industry that for fresh releases with no patches, a new release version omits the patch value. Essentially, version `1.2` **implies** `1.2.0`, meaning there is no patch yet.

I believe the keyword on the _semver_ spec is the use of **normal**. A new release is not _normal_, it's the first version of a new feature with no patch. Therefore an argument can be made that `Z` can be omitted.

There is an open [issue](https://github.com/mojombo/semver/issues/237) on the matter on _semver_.

Wikipedia's article on software versioning also omits the `0` on new releases. 
wikipedia: [software-versioning](https://en.wikipedia.org/wiki/Software_versioning)
