### PR TITLE
Fix non-capturing group syntax

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -44,7 +44,7 @@ lazy_static! {
             (?:\.(?P<minor>{}))?    # optional dot and then minor
             (?:\.(?P<patch>{}))?    # optional dot and then patch
             (?:-(?P<pre>{}))?       # optional prerelease version
-            (:?\+(?P<build>{}))?    # optional build metadata
+            (?:\+(?P<build>{}))?    # optional build metadata
             \s*$                    # trailing whitespace
             ",
             operation,

--- a/src/version.rs
+++ b/src/version.rs
@@ -7,7 +7,7 @@ use common;
 lazy_static! {
     static ref REGEX: Regex = {
         // a numeric identifier is either zero or multiple numbers without a leading zero
-        let numeric_identifier = r"0|(:?[1-9][0-9]*)";
+        let numeric_identifier = r"0|(?:[1-9][0-9]*)";
 
         let major = numeric_identifier;
         let minor = numeric_identifier;
@@ -29,8 +29,8 @@ lazy_static! {
             (?P<minor>{})           # minor version
             \.                      # dot
             (?P<patch>{})           # patch version
-            (:?-(?P<pre>{}))?       # optional prerelease version
-            (:?\+(?P<build>{}))?    # optional build metadata
+            (?:-(?P<pre>{}))?       # optional prerelease version
+            (?:\+(?P<build>{}))?    # optional build metadata
             $",
             major,
             minor,


### PR DESCRIPTION
A few `(?:)` were mistyped as `(:?)` which is an optional colon. This
changes the type of error returned for a version like `:1.2.3` from
invalid digit to version does not parse correctly.
