### PR TITLE
closes #4, integer overflow causes panic

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -169,7 +169,7 @@ pub fn parse_predicate(range: &str) -> Result<Predicate, String> {
                                 .map(Result::unwrap)
                                 .unwrap_or(Op::Compatible);
 
-    // first unwrap is okay because we always have major
+    // unwrap is okay because we always have major
     let major: Result<_, ParseIntError> = captures.name("major")
                         .unwrap()
                         .parse();


### PR DESCRIPTION
Simple fix for #4. Does not use `BigUint` or anything fancy, but it does provide a useful error message in case of a problem being encountered during parsing.