### PR TITLE
Fix multiple overflow errors

### DIFF
--- a/src/range.rs
+++ b/src/range.rs
@@ -179,22 +179,22 @@ pub fn parse_predicate(range: &str) -> Result<Predicate, String> {
                             Err(err) => return Err("Error parsing major version number: ".to_string() + err.description())
                 };
 
-    let minor = captures.name("minor");
-
-    // oh my what have I done? This code is gross.
-    let minor = if minor.is_some() {
-        let minor = minor.unwrap();
-        match minor.parse() {
-            Ok(number) => Some(number),
-            Err(_) => {
-                // if we get an error, it's because it's a wildcard
-                operation = Op::Wildcard(WildcardVersion::Minor);
-
-                None
-            },
-        }
-    } else {
-        None
+    let minor = match captures.name("minor") {
+        Some(minor) => {
+            match minor.parse::<u64>() {
+                Ok(number) => Some(number),
+                Err(err) => {
+                    match minor {
+                        "*" | "x" | "X"  => {
+                            operation = Op::Wildcard(WildcardVersion::Minor);
+                            None
+                        },
+                        _ => return Err("Error parsing minor version number: ".to_string() + err.description()),
+                    }
+                },
+            }
+        },
+        None => None,
     };
 
     let patch = captures.name("patch");
@@ -712,10 +712,15 @@ mod tests {
         assert!(range::parse("> 0.1.0,").is_err());
         assert!(range::parse("> 0.3.0, ,").is_err());
     }
-    
+
     #[test]
-    pub fn test_large_version() {
+    pub fn test_large_major_version() {
         assert!(range::parse("18446744073709551617.0.0").is_err());
+    }
+
+    #[test]
+    pub fn test_large_minor_version() {
+        assert!(range::parse("0.18446744073709551617.0").is_err());
     }
 
 }


### PR DESCRIPTION
Recently merged #10 helped handle overflow on the major version number, but didn't address overflow for the minor, patch, and meta version numbers.

Overflow on minor and patch versions currently causes them to be regarded as wildcards, so comparing very large minor or patch versions would mysteriously not work.

Prerelease numeric identifiers with overflow currently cause cargo to panic with an Overflow error. One potential place where this could happen is if someone tried adding a YmdHMSN timestamp (like `20170124231042736784549`) to their prerelease tag.  I'm not sure how I feel about calling a number AlphaNumeric when it is actually Numeric, but it seems better than crashing.

I am new to Rust, so please help me correct any unidiomatic usage.