### PR TITLE
Translate from regex to recognizer combinators

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,3 @@ documentation = "https://docs.rs/semver-parser"
 description = """
 Parsing of the semver spec
 """
-
-[dependencies]
-regex = "0.1"
-lazy_static = "0.2.1"

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,13 +1,14 @@
-use regex::Regex;
 use version::Identifier;
+use recognize::{Recognize, Alt, OneOrMore, Inclusive, OneByte};
+use std::str::from_utf8;
 
 // by the time we get here, we know that it's all valid characters, so this doesn't need to return
 // a result or anything
-pub fn parse_meta(s: &str) -> Vec<Identifier> {
+fn parse_meta(s: &str) -> Vec<Identifier> {
     // Originally, I wanted to implement this method via calling parse, but parse is tolerant of
     // leading zeroes, and we want anything with leading zeroes to be considered alphanumeric, not
-    // numeric. So the strategy is to check with a regex first, and then call parse once we've
-    // determined that it's a number without a leading zero.
+    // numeric. So the strategy is to check with a recognizer first, and then call parse once
+    // we've determined that it's a number without a leading zero.
     s.split(".")
         .map(|part| {
             // another wrinkle: we made sure that any number starts with a
@@ -23,9 +24,43 @@ pub fn parse_meta(s: &str) -> Vec<Identifier> {
         }).collect()
 }
 
+// parse optional metadata (preceded by the prefix character)
+pub fn parse_optional_meta(s: &[u8], prefix_char: u8)-> Result<(Vec<Identifier>, usize), String> {
+    if let Some(len) = prefix_char.p(s) {
+        let start = len;
+        if let Some(len) = letters_numbers_dash_dot(&s[start..]) {
+            let end = start + len;
+            Ok((parse_meta(from_utf8(&s[start..end]).unwrap()), end))
+        } else {
+            Err("Error parsing prerelease".to_string())
+        }
+    } else {
+        Ok((Vec::new(), 0))
+    }
+}
+
 pub fn is_alpha_numeric(s: &str) -> bool {
-    lazy_static! {
-        static ref REGEX: Regex = Regex::new(r"^(0|[1-9][0-9]*)$").unwrap();
-    };
-    !REGEX.is_match(s)
+    if let Some((_val, len)) = numeric_identifier(s.as_bytes()) {
+        // Return true for number with leading zero
+        // Note: doing it this way also handily makes overflow fail over.
+        len != s.len()
+    } else {
+        true
+    }
+}
+
+// Note: could plumb overflow error up to return value as Result
+pub fn numeric_identifier(s: &[u8]) -> Option<(u64, usize)> {
+    if let Some(len) = Alt(b'0', OneOrMore(Inclusive(b'0'..b'9'))).p(s) {
+        from_utf8(&s[0..len]).unwrap().parse().ok().map(|val| (val, len))
+    } else {
+        None
+    }
+}
+
+pub fn letters_numbers_dash_dot(s: &[u8]) -> Option<usize> {
+    OneOrMore(OneByte(|c| c == b'-' || c == b'.' ||
+        (b'0' <= c && c <= b'9') ||
+        (b'a' <= c && c <= b'z') ||
+        (b'A' <= c && c <= b'Z'))).p(s)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,8 @@
-extern crate regex;
-
-#[macro_use]
-extern crate lazy_static;
-
 pub mod version;
 pub mod range;
 
 // for private stuff the two share
 mod common;
+
+// for recognizer combinators
+mod recognize;

--- a/src/recognize.rs
+++ b/src/recognize.rs
@@ -1,4 +1,23 @@
 // Copyright 2017 Google Inc. All rights reserved.
+//
+// Licensed under either of MIT or Apache License, Version 2.0,
+// at your option.
+//
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file or at
+// https://opensource.org/licenses/MIT.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 //! Simple recognizer combinators.
 

--- a/src/recognize.rs
+++ b/src/recognize.rs
@@ -1,0 +1,135 @@
+// Copyright 2017 Google Inc. All rights reserved.
+
+//! Simple recognizer combinators.
+
+// This version is similar to a similar one in the "lang" module of
+// xi-editor, but is stripped down to only the needed combinators.
+
+use std::ops;
+
+pub trait Recognize {
+    fn p(&self, s: &[u8]) -> Option<usize>;
+}
+
+impl<F: Fn(&[u8]) -> Option<usize>> Recognize for F {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        self(s)
+    }
+}
+
+pub struct OneByte<F>(pub F);
+
+impl<F: Fn(u8) -> bool> Recognize for OneByte<F> {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        if s.is_empty() || !self.0(s[0]) {
+            None
+        } else {
+            Some(1)
+        }
+    }
+}
+
+impl Recognize for u8 {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        OneByte(|b| b == *self).p(s)
+    }
+}
+
+/// Use Inclusive(a..b) to indicate an inclusive range. When a...b syntax becomes
+/// stable, we can get rid of this and switch to that.
+pub struct Inclusive<T>(pub T);
+
+impl Recognize for Inclusive<ops::Range<u8>> {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        OneByte(|x| x >= self.0.start && x <= self.0.end).p(s)
+    }
+}
+
+impl<'a> Recognize for &'a [u8] {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        let len = self.len();
+        if s.len() >= len && &s[..len] == *self {
+            Some(len)
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a> Recognize for &'a str {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        self.as_bytes().p(s)
+    }
+}
+
+impl<P1: Recognize, P2: Recognize> Recognize for (P1, P2) {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        self.0.p(s).and_then(|len1|
+            self.1.p(&s[len1..]).map(|len2|
+                len1 + len2))
+    }
+}
+
+/// Choice from two heterogeneous alternatives.
+pub struct Alt<P1, P2>(pub P1, pub P2);
+
+impl<P1: Recognize, P2: Recognize> Recognize for Alt<P1, P2> {
+    #[inline(always)]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        self.0.p(s).or_else(|| self.1.p(s))
+    }
+}
+
+/// Choice from a homogenous slice of parsers.
+pub struct OneOf<'a, P: 'a>(pub &'a [P]);
+
+impl<'a, P: Recognize> Recognize for OneOf<'a, P> {
+    #[inline]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        for ref p in self.0 {
+            if let Some(len) = p.p(s) {
+                return Some(len);
+            }
+        }
+        None
+    }
+}
+
+pub struct OneOrMore<P>(pub P);
+
+impl<P: Recognize> Recognize for OneOrMore<P> {
+    #[inline]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        let mut i = 0;
+        let mut count = 0;
+        while let Some(len) = self.0.p(&s[i..]) {
+            i += len;
+            count += 1;
+        }
+        if count >= 1 {
+            Some(i)
+        } else {
+            None
+        }
+    }
+}
+
+pub struct ZeroOrMore<P>(pub P);
+
+impl<P: Recognize> Recognize for ZeroOrMore<P> {
+    #[inline]
+    fn p(&self, s: &[u8]) -> Option<usize> {
+        let mut i = 0;
+        while let Some(len) = self.0.p(&s[i..]) {
+            i += len;
+        }
+        Some(i)
+    }
+}


### PR DESCRIPTION
Gets rid of the dependency on regex and uses recognizer combinators.
The recognizers are just included, rather than having a dependency on
a separate crate, as they're small and simple enough.

Also adds some tests to make sure numeric overflow is handled without
panic (the previous version would not pass these).