### PR TITLE
Allow parsing not-quite-semver versions

### DIFF
--- a/src/version.rs
+++ b/src/version.rs
@@ -34,6 +34,15 @@ pub fn parse(version: &str) -> Result<Version, String> {
     if let Some(len) = b'.'.p(&s[i..]) {
         i += len;
     } else {
+        if i == s.len() {
+            return Ok(Version {
+                major: major,
+                minor: 0,
+                patch: 0,
+                pre: vec![],
+                build: vec![],
+            });
+        }
         return Err("Expected dot".to_string());
     }
     let minor = if let Some((minor, len)) = numeric_identifier(&s[i..]) {
@@ -45,6 +54,15 @@ pub fn parse(version: &str) -> Result<Version, String> {
     if let Some(len) = b'.'.p(&s[i..]) {
         i += len;
     } else {
+        if i == s.len() {
+            return Ok(Version {
+                major: major,
+                minor: minor,
+                patch: 0,
+                pre: vec![],
+                build: vec![],
+            });
+        }
         return Err("Expected dot".to_string());
     }
     let patch = if let Some((patch, len)) = numeric_identifier(&s[i..]) {
@@ -123,18 +141,22 @@ mod tests {
     fn parse_no_minor_patch() {
         let version = "1";
 
-        let parsed = version::parse(version);
+        let parsed = version::parse(version).unwrap();
 
-        assert!(parsed.is_err(), format!("'{}' incorrectly considered a valid parse", version));
+        assert_eq!(1, parsed.major);
+        assert_eq!(0, parsed.minor);
+        assert_eq!(0, parsed.patch);
     }
 
     #[test]
     fn parse_no_patch() {
         let version = "1.2";
 
-        let parsed = version::parse(version);
+        let parsed = version::parse(version).unwrap();
 
-        assert!(parsed.is_err(), format!("'{}' incorrectly considered a valid parse", version));
+        assert_eq!(1, parsed.major);
+        assert_eq!(2, parsed.minor);
+        assert_eq!(0, parsed.patch);
     }
 
     #[test]


### PR DESCRIPTION
Ref. Lenient parsing of not-quite-semver versions steveklabnik/semver#142

Change the behaviour for parsing not-quite-semver versions, specifically when there is only a major section, and when there is no patch section. Rather than error out, we check if we are at the end of the string. If so, then we return the version with all the information we know so far and zero out the rest. If we are not at the end of the string then we error out with the same error message.

The version formats this PR addresses are:
- `parse("1")` which has `major=1; minor=0; patch=0`
- `parse("1.2")` which has `major=1; minor=2; patch=0`
- `parse("1.2-beta")` which has `major=1; minor=2; patch=0; pre=beta`
- `parse("1.2+build")` which has `major=1; minor=2; patch=0; build=build`