### PR TITLE
Make Parser.pre public

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -175,7 +175,7 @@ impl<'input> Parser<'input> {
     /// Parse all pre-release identifiers, separated by dots.
     ///
     /// Like, `abcdef.1234`.
-    fn pre(&mut self) -> Result<Vec<Identifier>, Error<'input>> {
+    pub fn pre(&mut self) -> Result<Vec<Identifier>, Error<'input>> {
         match self.peek() {
             Some(&Token::Hyphen) => {}
             _ => return Ok(vec![]),

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -204,7 +204,7 @@ impl<'input> Parser<'input> {
     /// Parse optional build metadata.
     ///
     /// Like, `` (empty), or `+abcdef`.
-    fn plus_build_metadata(&mut self) -> Result<Vec<Identifier>, Error<'input>> {
+    pub fn plus_build_metadata(&mut self) -> Result<Vec<Identifier>, Error<'input>> {
         match self.peek() {
             Some(&Token::Plus) => {}
             _ => return Ok(vec![]),


### PR DESCRIPTION
I'm optionally parsing parts of a version using the Parser, but it seems the `pre` function was not public.

Edit: Also plus_build_metadata