### PR TITLE
rename `Compat::Node` to `Compat::Npm`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -7,8 +7,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let range_set: RangeSet = "1.2.3".parse()?;
     println!("Found range set: {:?}", range_set);
 
-    // node compatibility
-    let range_set = RangeSet::parse("1.2.3", Compat::Node)?;
+    // npm compatibility
+    let range_set = RangeSet::parse("1.2.3", Compat::Npm)?;
     println!("Found range set (node): {:?}", range_set);
 
     Ok(())

--- a/src/range.rs
+++ b/src/range.rs
@@ -183,7 +183,7 @@ pub mod simple {
                         }
                         PartialKind::MajorMinorPatch => {
                             match compat {
-                                range_set::Compat::Node => {
+                                range_set::Compat::Npm => {
                                     // for node, "1.2.3" is "=1.2.3"
                                     comparators.push(partial.as_comparator(Op::Eq));
                                 }
@@ -612,7 +612,7 @@ mod tests {
                     let (input, expected_range) = $value;
 
                     let parsed_range = parse_range(input);
-                    let range = from_pair_iterator(parsed_range, range_set::Compat::Node).expect("parsing failed");
+                    let range = from_pair_iterator(parsed_range, range_set::Compat::Npm).expect("parsing failed");
 
                     // get the expected length from the input range
                     let num_comparators = range.comparator_set.len();
@@ -676,7 +676,7 @@ mod tests {
                         },
                     )*
                 ],
-                compat: range_set::Compat::Node
+                compat: range_set::Compat::Npm
             }
         };
     }

--- a/src/range_set.rs
+++ b/src/range_set.rs
@@ -12,7 +12,7 @@ pub struct RangeSet {
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
 pub enum Compat {
     Cargo, // default
-    Node,
+    Npm,
 }
 
 impl RangeSet {
@@ -112,7 +112,7 @@ mod tests {
                 fn $name() {
                     let expected_sets = vec![$($x)*];
 
-                    let range_set = RangeSet::parse($input, Compat::Node).expect("parse failed");
+                    let range_set = RangeSet::parse($input, Compat::Npm).expect("parse failed");
 
                     assert_eq!(range_set.ranges.len(), expected_sets.len());
                     for it in range_set.ranges.iter().zip(expected_sets.iter()) {


### PR DESCRIPTION
Technically these are associated with the tools, not the languages.
https://github.com/steveklabnik/semver/pull/209#issuecomment-690855508