### PR TITLE
Added token position when an error has been raised

### DIFF
--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -319,17 +319,6 @@ mod tests {
     }
 
     #[test]
-    pub fn unexpected_character_position() {
-        let mut lexer = Lexer::new("/");
-        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 1))));
-        lexer = Lexer::new("123 */");
-        assert_eq!(lexer.next(), Some(Ok(Numeric(123))));
-        assert_eq!(lexer.next(), Some(Ok(Whitespace(3, 4))));
-        assert_eq!(lexer.next(), Some(Ok(Star)));
-        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 6))));
-    }
-
-    #[test]
     pub fn is_wildcard() {
         assert_eq!(Star.is_wildcard(), true);
         assert_eq!(AlphaNumeric("x").is_wildcard(), true);
@@ -355,5 +344,16 @@ mod tests {
             .collect();
 
         assert_eq!(actual, expected);
+    }
+
+    #[test]
+    pub fn unexpected_character_position() {
+        let mut lexer = Lexer::new("/");
+        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 1))));
+        lexer = Lexer::new("123 */");
+        lexer.next(); // Some(Ok(Numeric(123)))
+        lexer.next(); // Some(Ok(Whitespace(3, 4)))
+        lexer.next(); // Some(Ok(Star))
+        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 6))));
     }
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -32,7 +32,7 @@
 //!
 //! assert_eq!(Some(Ok(Token::AlphaNumeric("foo"))), l.next());
 //! assert_eq!(Some(Ok(Token::Whitespace(3, 4))), l.next());
-//! assert_eq!(Some(Err(Error::UnexpectedChar('/'))), l.next());
+//! assert_eq!(Some(Err(Error::UnexpectedChar('/', 5))), l.next());
 //! ```
 
 use self::Error::*;
@@ -143,7 +143,7 @@ impl<'input> Lexer<'input> {
         let mut chars = input.char_indices();
         let c1 = chars.next();
         let c2 = chars.next();
-        let position = 0;
+        let position = 1;
 
         Lexer {
             input,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -109,6 +109,7 @@ impl<'input> Token<'input> {
             Eq | Gt | Lt | LtEq | GtEq | Caret | Tilde | Star | Dot | Comma | Hyphen | Plus => 1,
             Or => 2,
             Whitespace(b_index, e_index) => e_index - b_index,
+            // TODO: find a better way (lower cost) to compute the number of digits in a given number
             Numeric(num) => num.to_string().len(),
             AlphaNumeric(alpha) => alpha.len(),
         }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -103,6 +103,17 @@ pub enum Token<'input> {
 }
 
 impl<'input> Token<'input> {
+    // Returns the number of characters per token.
+    pub fn len(&self) -> usize {
+        match self {
+            Eq | Gt | Lt | LtEq | GtEq | Caret | Tilde | Star | Dot | Comma | Hyphen | Plus => 1,
+            Or => 2,
+            Whitespace(b_index, e_index) => e_index - b_index,
+            Numeric(num) => num.to_string().len(),
+            AlphaNumeric(alpha) => alpha.len(),
+        }
+    }
+
     /// Check if the current token is a whitespace token.
     pub fn is_whitespace(&self) -> bool {
         match *self {
@@ -302,6 +313,17 @@ mod tests {
         assert_eq!(lex("5885644aa"), vec![AlphaNumeric("5885644aa")]);
         assert_eq!(lex("beta2"), vec![AlphaNumeric("beta2")]);
         assert_eq!(lex("beta.2"), vec![AlphaNumeric("beta"), Dot, Numeric(2)]);
+    }
+
+    #[test]
+    pub fn unexpected_character_position() {
+        let mut lexer = Lexer::new("/");
+        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 1))));
+        lexer = Lexer::new("123 */");
+        assert_eq!(lexer.next(), Some(Ok(Numeric(123))));
+        assert_eq!(lexer.next(), Some(Ok(Whitespace(3, 4))));
+        assert_eq!(lexer.next(), Some(Ok(Star)));
+        assert_eq!(lexer.next(), Some(Err(Error::UnexpectedChar('/', 6))));
     }
 
     #[test]

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -155,7 +155,7 @@ impl<'input> Lexer<'input> {
         let mut chars = input.char_indices();
         let c1 = chars.next();
         let c2 = chars.next();
-        let position = 1;
+        let position = if c1.is_none() { 0 } else { 1 };
 
         Lexer {
             input,

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -170,7 +170,9 @@ impl<'input> Lexer<'input> {
     fn step(&mut self) {
         self.c1 = self.c2;
         self.c2 = self.chars.next();
-        self.position += 1;
+        if self.c1.is_some() {
+            self.position += 1;
+        }
     }
 
     fn step_n(&mut self, n: usize) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,4 +20,4 @@ pub mod parser;
 pub mod version;
 
 // Defines the type to describe where (character position) the error is
-type ErrorPosition = u32;
+type ErrorPosition = usize;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,3 +18,6 @@ pub mod lexer;
 pub mod parser;
 // pub mod range;
 pub mod version;
+
+// Defines the type to describe where (character position) the error is
+type ErrorPosition = u32;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -92,14 +92,13 @@ impl<'input> Parser<'input> {
     #[inline(always)]
     fn pop(&mut self) -> Result<Token<'input>, Error<'input>> {
         let c1 = if let Some(c1) = self.lexer.next() {
-            let c1 = c1?;
             // Count the previous characters
             if self.c1.is_some() {
                 self.position += self.c1.as_ref().unwrap().len();
             }
-            Some(c1)
+            Some(c1?)
         } else {
-            // Count the current character
+            // Increment to get the index of the current token
             self.position += 1;
             None
         };

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -94,7 +94,7 @@ impl<'input> Parser<'input> {
         let c1 = if let Some(c1) = self.lexer.next() {
             // Count the previous characters
             if self.c1.is_some() {
-                self.position += self.c1.as_ref().unwrap().len();
+                self.position += self.peek().unwrap().len();
             }
             Some(c1?)
         } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -75,10 +75,7 @@ impl<'input> Parser<'input> {
     pub fn new(input: &'input str) -> Result<Parser<'input>, Error<'input>> {
         let mut lexer = Lexer::new(input);
 
-        let mut position = 0;
-
         let c1 = if let Some(c1) = lexer.next() {
-            position += 1;
             Some(c1?)
         } else {
             None
@@ -87,7 +84,7 @@ impl<'input> Parser<'input> {
         Ok(Parser {
             lexer,
             c1,
-            position,
+            position: 0, // Start at position 0
         })
     }
 
@@ -95,9 +92,15 @@ impl<'input> Parser<'input> {
     #[inline(always)]
     fn pop(&mut self) -> Result<Token<'input>, Error<'input>> {
         let c1 = if let Some(c1) = self.lexer.next() {
-            self.position += 1;
-            Some(c1?)
+            let c1 = c1?;
+            // Count the previous characters
+            if self.c1.is_some() {
+                self.position += self.c1.as_ref().unwrap().len();
+            }
+            Some(c1)
         } else {
+            // Count the current character
+            self.position += 1;
             None
         };
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -231,6 +231,42 @@ mod tests {
     }
 
     #[test]
+    fn parse_empty_pre() {
+        let version = "1.2.3-";
+
+        let parsed = version::parse(version);
+
+        assert!(
+            parsed.is_err(),
+            format!("'{}' incorrectly considered a valid parse", version)
+        );
+    }
+
+    #[test]
+    fn parse_letters() {
+        let version = "a.b.c";
+
+        let parsed = version::parse(version);
+
+        assert!(
+            parsed.is_err(),
+            format!("'{}' incorrectly considered a valid parse", version)
+        );
+    }
+
+    #[test]
+    fn parse_with_letters() {
+        let version = "1.2.3 a.b.c";
+
+        let parsed = version::parse(version);
+
+        assert!(
+            parsed.is_err(),
+            format!("'{}' incorrectly considered a valid parse", version)
+        );
+    }
+
+    #[test]
     fn parse_first_unexpected_token_error() {
         let version = "x";
 
@@ -275,42 +311,6 @@ mod tests {
         assert_eq!(
             parsed.unwrap_err(),
             parser::Error::UnexpectedToken(lexer::Token::AlphaNumeric("x"), 5)
-        );
-    }
-
-    #[test]
-    fn parse_empty_pre() {
-        let version = "1.2.3-";
-
-        let parsed = version::parse(version);
-
-        assert!(
-            parsed.is_err(),
-            format!("'{}' incorrectly considered a valid parse", version)
-        );
-    }
-
-    #[test]
-    fn parse_letters() {
-        let version = "a.b.c";
-
-        let parsed = version::parse(version);
-
-        assert!(
-            parsed.is_err(),
-            format!("'{}' incorrectly considered a valid parse", version)
-        );
-    }
-
-    #[test]
-    fn parse_with_letters() {
-        let version = "1.2.3 a.b.c";
-
-        let parsed = version::parse(version);
-
-        assert!(
-            parsed.is_err(),
-            format!("'{}' incorrectly considered a valid parse", version)
         );
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -179,6 +179,7 @@ impl fmt::Display for Identifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::lexer;
     use crate::version;
 
     #[test]
@@ -226,6 +227,54 @@ mod tests {
         assert!(
             parsed.is_err(),
             format!("'{}' incorrectly considered a valid parse", version)
+        );
+    }
+
+    #[test]
+    fn parse_first_unexpected_token_error() {
+        let version = "x";
+
+        let parsed = version::parse(version);
+
+        assert_eq!(
+            parsed.unwrap_err(),
+            parser::Error::UnexpectedToken(lexer::Token::AlphaNumeric("x"), 1)
+        );
+    }
+
+    #[test]
+    fn parse_first_unexpected_token_error_with_spaces() {
+        let version = "  x ";
+
+        let parsed = version::parse(version);
+
+        assert_eq!(
+            parsed.unwrap_err(),
+            parser::Error::UnexpectedToken(lexer::Token::AlphaNumeric("x"), 3)
+        );
+    }
+
+    #[test]
+    fn parse_middle_unexpected_token_error() {
+        let version = "1.x.3";
+
+        let parsed = version::parse(version);
+
+        assert_eq!(
+            parsed.unwrap_err(),
+            parser::Error::UnexpectedToken(lexer::Token::AlphaNumeric("x"), 3)
+        );
+    }
+
+    #[test]
+    fn parse_last_unexpected_token_error() {
+        let version = "1.2.x";
+
+        let parsed = version::parse(version);
+
+        assert_eq!(
+            parsed.unwrap_err(),
+            parser::Error::UnexpectedToken(lexer::Token::AlphaNumeric("x"), 5)
         );
     }
 


### PR DESCRIPTION
In order to resolve #44, I added a new information in `Lexer` and `Parser` structure, that contains the position of the character under the cursor.

I added this information in the `Error` enum, in order to print it or let it to the developer, in order to know at which position an error has been encountered.

Character position starts from 1.
So, an error at position 2 in the token 'abc' points to the 'b' character.

I added some unit tests in `lexer.rs` and `version.rs` to test mostly `UnexpectedToken` and `UnexpectedChar` errors. 

Note: as I wasn't sure about the right type to use for the error position, I made a type exposed for both `lexer.rs` and `parser.rs` to let them use the same type.  
I can remove it as soon as a right type (usize, u32?) has been decided.