### PR TITLE
Update grammar to disallow numerical pre-release identifiers followed by non-digit characters

### DIFF
--- a/src/range_set.rs
+++ b/src/range_set.rs
@@ -135,6 +135,7 @@ mod tests {
     }
 
     range_set_test!( one_range: "=1.2.3", 1 );
+    range_set_test!( one_range_with_alphanumerical_prerelease: "=0.3.0-alpha.2a", 1 );
     range_set_test!( one_range_cargo: "1.2.3", 2 ); // this parses as "^1.2.3"
     range_set_test!( one_range_with_space: "   =1.2.3 ", 1 );
     range_set_test!( two_ranges: ">1.2.3 || =4.5.6", 1, 1 );
@@ -161,5 +162,6 @@ mod tests {
         err_hyphen_with_gt: "1.2.3 - >3.4.5",
         err_hyphen_no_2nd_version: "1.2.3 - ",
         err_no_pre_hyphen: "~1.2.3beta",
+        err_leading_0_prerelease: "1.2.3-alpha.04",
     }
 }

--- a/src/semver.pest
+++ b/src/semver.pest
@@ -14,5 +14,6 @@ tilde      = { ( "~>" | "~" ) ~ space* ~ partial }
 caret      = { "^" ~ space* ~ partial }
 qualifier  = { (("-" | "+") ~ parts) }
 parts      = { part ~ ("." ~ part)* }
-part       = { nr | ("-" | '0' .. '9' | 'A' .. 'Z' | 'a' .. 'z')+ }
+alphasym   = { "-" | 'A' .. 'Z' | 'a' .. 'z' }
+part       = { ( nr ~ !alphasym ) | ('0' .. '9' | alphasym)+ }
 space      = _{ " " | "\t" }


### PR DESCRIPTION
Resolves #55 by peeking for non-digits after a predicted `nr` part, which could otherwise leave the pre-release identifier part underconsumed. Test cases were included.