### PR TITLE
OSS-Fuzz: OSS-Fuzz integration and new fuzzers

### DIFF
--- a/fuzz/.gitignore
+++ b/fuzz/.gitignore
@@ -1,0 +1,4 @@
+target
+corpus
+artifacts
+coverage

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -1,0 +1,22 @@
+[package]
+name = "semver-parser-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2018"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+proc-macro2 = "1.0"
+
+[dependencies.semver-parser]
+path = ".."
+
+[[bin]]
+name = "parse"
+path = "fuzz_targets/parse.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/parse.rs
+++ b/fuzz/fuzz_targets/parse.rs
@@ -1,0 +1,43 @@
+// Copyright 2024 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![no_main]
+
+use libfuzzer_sys::fuzz_target;
+use semver_parser::{lexer::Lexer, parser::Parser, Compat};
+
+fuzz_target!(|data: &[u8]| {
+    if let Ok(s) = std::str::from_utf8(data) {
+        let _ = format!("{}\n{}", "", s).parse::<proc_macro2::TokenStream>();
+
+        // Fuzz Lexer
+        let mut lexer = Lexer::new(s);
+        while let Some(token) = lexer.next() {
+            match token {
+                Err(_) => break,
+                Ok(_) => {}
+            }
+        }
+
+        // Fuzz Parser
+        if let Ok(mut parser) = Parser::new(s) {
+            let _ = parser.version();
+        }
+
+        // Fuzz Compat
+        for compat in &[Compat::Cargo, Compat::Npm] {
+            let _ = format!("{:?}", compat);
+        }
+    }
+});


### PR DESCRIPTION
Hi! Would you be interested in setting up fuzzing for the semver-parser module via OSS-Fuzz?

Fuzzing is essentially a stress-testing approach used to find bugs in software, and OSS-Fuzz is a free service run by Google that continuously fuzzes important open-source projects. Integrating your module with OSS-Fuzz could help uncover memory corruption issues that may exist.

This PR adds a Cargo fuzz configuration along with a fuzzer for the semver-parser module. In combination with an initial attempt in OSS-Fuzz (https://github.com/google/oss-fuzz/pull/12636), it enables OSS-Fuzz to fuzz the semver-parser module while keeping the fuzzers upstream for further modification and expansion. If you're happy to proceed with the integration and store the fuzzers upstream, please let me know, and I'd be glad to provide more details if needed.

The only thing required at this point is an email associated with a Google account, which will be used to receive notifications when bugs are found.